### PR TITLE
fix: update GitHub username from jackd248 to konradmichalik

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Renovate config
 
-[![CGL](https://github.com/jackd248/renovate-config/actions/workflows/cgl.yml/badge.svg)](https://github.com/jackd248/renovate-config/actions/workflows/cgl.yml)
-[![Release](https://github.com/jackd248/renovate-config/actions/workflows/release.yml/badge.svg)](https://github.com/jackd248/renovate-config/actions/workflows/release.yml)
-[![License](https://img.shields.io/github/license/jackd248/renovate-config)](LICENSE)
+[![CGL](https://github.com/konradmichalik/renovate-config/actions/workflows/cgl.yml/badge.svg)](https://github.com/konradmichalik/renovate-config/actions/workflows/cgl.yml)
+[![Release](https://github.com/konradmichalik/renovate-config/actions/workflows/release.yml/badge.svg)](https://github.com/konradmichalik/renovate-config/actions/workflows/release.yml)
+[![License](https://img.shields.io/github/license/konradmichalik/renovate-config)](LICENSE)
 
 </div>
 
@@ -22,7 +22,7 @@ This repository contains my personal [renovate](https://docs.renovatebot.com/) c
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "github>jackd248/renovate-config"
+        "github>konradmichalik/renovate-config"
     ]
 }
 ```

--- a/default.json
+++ b/default.json
@@ -15,7 +15,7 @@
 ],
 "timezone": "Europe/Berlin",
 "assignees": [
-	"jackd248"
+	"konradmichalik"
 ],
 "commitBodyTable": true,
 "composerIgnorePlatformReqs": null,


### PR DESCRIPTION
## Summary

- Update GitHub username references from `jackd248` to `konradmichalik` across the repository

## Changes

- `README.md` - Update badge URLs, license link, and usage example to new username
- `default.json` - Update Renovate assignee to new username

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository URLs and badges in documentation to reflect current repository location.

* **Chores**
  * Updated configuration metadata assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->